### PR TITLE
fix: correct the difficulty adjustment formula in Chapter 12

### DIFF
--- a/ch12_mining.adoc
+++ b/ch12_mining.adoc
@@ -463,7 +463,7 @@ structure of the((("inputs", "coinbase versus regular transactions"))) coinbase 
 
 ++++
 <table id="table_8-1">
-<caption>The structure of a “normal” transaction input</caption>
+<caption>The structure of a "normal" transaction input</caption>
 <thead>
 <tr>
 <th>Size</th>
@@ -598,7 +598,7 @@ as listed in <<block_header_structure_ch10>>.
 <tr>
 <td><p>32 bytes</p></td>
 <td><p>Merkle Root</p></td>
-<td><p>A hash that is the root of the merkle tree of this block’s transactions</p></td>
+<td><p>A hash that is the root of the merkle tree of this block's transactions</p></td>
 </tr>
 <tr>
 <td><p>4 bytes</p></td>
@@ -941,7 +941,7 @@ The equation can be summarized as:
 
 
 ----
-New Target = Old Target * (20,160 minutes / Actual Time of Last 2015 Blocks)
+New Target = Old Target * (Actual Time of Last 2015 Blocks / 20,160 minutes)
 ----
 
 [NOTE]


### PR DESCRIPTION
# Fix Difficulty Adjustment Formula

## Issue Description
In Chapter 12 (Mining), there is an error in the Bitcoin difficulty adjustment formula. The current formula is:
New Target = Old Target * (20,160 minutes / Actual Time of Last 2015 Blocks)
This formula causes the difficulty adjustment to work in the opposite direction of what is intended:
- When actual block time is greater than expected time (20,160 minutes), difficulty increases instead of decreasing
- When actual block time is less than expected time, difficulty decreases instead of increasing

## Changes Made
Modified the formula to:
New Target = Old Target * (Actual Time of Last 2015 Blocks / 20,160 minutes)

## Rationale
1. Difficulty adjustment should be proportional to actual block time
2. When actual block time is longer, difficulty should decrease (target increases) to make mining easier
3. When actual block time is shorter, difficulty should increase (target decreases) to make mining harder
4. The corrected formula aligns with Bitcoin network's intended behavior

## Impact
- Corrects the difficulty adjustment calculation logic
- Ensures difficulty adjustment direction matches network requirements
- Helps maintain stable block generation time around 10 minutes

## Testing
- Verified the modified formula's behavior across different time spans
- Confirmed difficulty adjustment direction meets expectations